### PR TITLE
Quality of life changes for the enumerator.

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/aws-enumerator.iml
+++ b/.idea/aws-enumerator.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="Go" enabled="true" />
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/aws-enumerator.iml" filepath="$PROJECT_DIR$/.idea/aws-enumerator.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/shabarkin/aws-enumerator
 go 1.15
 
 require (
+	github.com/aws/aws-sdk-go-v2 v1.3.2 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.1.5
 	github.com/aws/aws-sdk-go-v2/service/acm v1.2.2
 	github.com/aws/aws-sdk-go-v2/service/amplify v1.1.5

--- a/helper/helper.go
+++ b/helper/helper.go
@@ -3,9 +3,9 @@ package helper
 import (
 	"flag"
 	"fmt"
-
 	"github.com/shabarkin/aws-enumerator/servicemaster"
 	"github.com/shabarkin/aws-enumerator/servicestructs"
+
 	"github.com/shabarkin/aws-enumerator/utils"
 )
 
@@ -20,18 +20,20 @@ func changeSpeedForTime(speed string) (time int) {
 	return time
 }
 
-func SetEnumerationPipeline(services, speed *string) {
+func SetEnumerationPipeline(services, speed *string, profile *string) {
 	// Load Global Variables from file
-	utils.LoadEnv()
+	if *profile == "" {
+		fmt.Println(utils.Green("Message: "), utils.Yellow("No AWS profile specified, attempting to load from .env file"))
+		utils.LoadEnv()
+	}
 
-	if servicemaster.CheckAWSCredentials() {
-
+	fmt.Println(utils.Green("Message: "), utils.Yellow("profile name: "), utils.Cyan(*profile))
+	if servicemaster.CheckAWSCredentials(profile) {
 		servicemaster.ServiceCall(
-			servicestructs.GetServices(),
+			servicestructs.GetServices(profile),
 			utils.ProcessServiceArgument(*services),
 			changeSpeedForTime(*speed),
 		)
-
 	}
 }
 
@@ -80,10 +82,11 @@ aws-enumerator enum [command]
 Flags:
   -services     Enumerate permissions specifying services divided by comma or 'all' for total enumeration
   -speed        Speed parameter has three defitions : fast or normal or slow (default is normal)
+  -profile      Specify AWS profile to use for authentication
 
 Example:
-  ./aws-enumerator enum -services iam,sts,s3,ec2 -speed normal
-  ./aws-enumerator enum -services all
+  ./aws-enumerator enum -services iam,sts,s3,ec2 -speed normal -profile pwnedlabs
+  ./aws-enumerator enum -services all -profile pwnedlabs
 `
 
 var Cloudrider_dump_help string = `Usage:
@@ -120,6 +123,7 @@ var AWS_session_token *string = Cred.String("aws_session_token", "", "")
 var Enum *flag.FlagSet = flag.NewFlagSet("enum", flag.ExitOnError)
 var Services_enum *string = Enum.String("services", "all", "")
 var Speed *string = Enum.String("speed", "normal", "")
+var Profile *string = Enum.String("profile", "", "")
 
 var Dump *flag.FlagSet = flag.NewFlagSet("dump", flag.ExitOnError)
 var Services_dump *string = Dump.String("services", "all", "")

--- a/main.go
+++ b/main.go
@@ -33,8 +33,8 @@ func main() {
 		fmt.Println(utils.Green("Message: "), utils.Yellow("File"), utils.Red(".env"), utils.Yellow("with AWS credentials were created in current folder"))
 	case "enum":
 		helper.Enum.Parse(os.Args[2:])
-		helper.SetEnumerationPipeline(helper.Services_enum, helper.Speed)
-		fmt.Println(utils.Green("Message: "), utils.Yellow("Enumeration finished"))
+		helper.SetEnumerationPipeline(helper.Services_enum, helper.Speed, helper.Profile)
+		fmt.Println(utils.Green("Message:"), utils.Yellow("Enumeration finished"))
 
 	case "dump":
 		helper.Dump.Parse(os.Args[2:])

--- a/main.go
+++ b/main.go
@@ -34,7 +34,7 @@ func main() {
 	case "enum":
 		helper.Enum.Parse(os.Args[2:])
 		helper.SetEnumerationPipeline(helper.Services_enum, helper.Speed, helper.Profile)
-		fmt.Println(utils.Green("Message:"), utils.Yellow("Enumeration finished"))
+		fmt.Println(utils.Green("Message:"), utils.Yellow("Enumeration Finished"))
 
 	case "dump":
 		helper.Dump.Parse(os.Args[2:])

--- a/servicemaster/servicemaster.go
+++ b/servicemaster/servicemaster.go
@@ -78,7 +78,7 @@ func (svc *ServiceMaster) control_node() {
 			defer close(svc.api_call_error_channel)
 			fmt.Println(utils.Green("Message: "), utils.Yellow("Successful"), utils.Yellow(strings.ToUpper(svc.SvcName))+utils.Yellow(":"), utils.Green(svc.result_counter-svc.error_counter), utils.Yellow("/"), utils.Red(svc.result_counter))
 			if svc.result_counter-svc.error_counter > 0 {
-				message := utils.Green("Message: ") + utils.Yellow("Successful ") + utils.Yellow(strings.ToUpper(svc.SvcName)) + " " + utils.Yellow(":") + utils.Green(svc.result_counter-svc.error_counter) + utils.Yellow("/") + utils.Red(svc.result_counter)
+				message := utils.Green("Message: ") + utils.Yellow("Successful ") + utils.Yellow(strings.ToUpper(svc.SvcName)) + utils.Yellow(": ") + utils.Green(svc.result_counter-svc.error_counter) + utils.Yellow("/") + utils.Red(svc.result_counter)
 				PositiveResults = append(PositiveResults, message)
 			}
 			break

--- a/servicemaster/servicemaster.go
+++ b/servicemaster/servicemaster.go
@@ -76,7 +76,7 @@ func (svc *ServiceMaster) control_node() {
 			defer close(svc.api_call_error_channel)
 			fmt.Println(utils.Green("Message: "), utils.Yellow("Successful"), utils.Yellow(strings.ToUpper(svc.SvcName))+utils.Yellow(":"), utils.Green(svc.result_counter-svc.error_counter), utils.Yellow("/"), utils.Red(svc.result_counter))
 			if svc.result_counter-svc.error_counter > 0 {
-				message := utils.Green("Message: ") + utils.Yellow("Successful") + utils.Yellow(strings.ToUpper(svc.SvcName)) + utils.Yellow(":") + utils.Green(svc.result_counter-svc.error_counter) + utils.Yellow("/") + utils.Red(svc.result_counter)
+				message := utils.Green("Message: ") + utils.Yellow("Successful ") + utils.Yellow(strings.ToUpper(svc.SvcName)) + utils.Yellow(":") + utils.Green(svc.result_counter-svc.error_counter) + utils.Yellow("/") + utils.Red(svc.result_counter)
 				PositiveResults = append(PositiveResults, message)
 			}
 			break

--- a/servicemaster/servicemaster.go
+++ b/servicemaster/servicemaster.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/shabarkin/aws-enumerator/utils"
 )
+var PositiveResults []string
 
 type ServiceMaster struct {
 	Svc     interface{}
@@ -74,6 +75,10 @@ func (svc *ServiceMaster) control_node() {
 			defer close(svc.api_call_result_channel)
 			defer close(svc.api_call_error_channel)
 			fmt.Println(utils.Green("Message: "), utils.Yellow("Successful"), utils.Yellow(strings.ToUpper(svc.SvcName))+utils.Yellow(":"), utils.Green(svc.result_counter-svc.error_counter), utils.Yellow("/"), utils.Red(svc.result_counter))
+			if svc.result_counter-svc.error_counter > 0 {
+				message := utils.Green("Message: ") + utils.Yellow("Successful") + utils.Yellow(strings.ToUpper(svc.SvcName)) + utils.Yellow(":") + utils.Green(svc.result_counter-svc.error_counter) + utils.Yellow("/") + utils.Red(svc.result_counter)
+				PositiveResults = append(PositiveResults, message)
+			}
 			break
 		}
 
@@ -198,4 +203,8 @@ func ServiceCall(AllAWSServices []ServiceMaster, wanted_services []string, speed
 	t := time.Now()
 	elapsed := t.Sub(start)
 	fmt.Println(utils.Green("Time:"), elapsed)
+	fmt.Println(utils.Green("Positive Results:"))
+	for i := 0; i < len(PositiveResults); i++ {
+		fmt.Println(PositiveResults[i])
+	}
 }

--- a/servicestructs/servicestructs.go
+++ b/servicestructs/servicestructs.go
@@ -2,6 +2,7 @@ package servicestructs
 
 import (
 	"context"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"log"
 
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -114,10 +115,18 @@ import (
 	"github.com/shabarkin/aws-enumerator/utils"
 )
 
-func GetServices() []servicemaster.ServiceMaster {
+func GetServices(profile *string) []servicemaster.ServiceMaster {
 
-	cfg, err := config.LoadDefaultConfig(context.TODO())
+	var (
+		cfg aws.Config
+		err error
+	)
 
+	if *profile == "" {
+		cfg, err = config.LoadDefaultConfig(context.TODO())
+	}
+
+	cfg, err = config.LoadDefaultConfig(context.TODO(), config.WithSharedConfigProfile(*profile))
 	if err != nil {
 		log.Fatalln(utils.Red("Error:"), utils.Yellow("Unable to load SDK config,"))
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"reflect"
+	"runtime"
 	"strings"
 
 	"github.com/fatih/color"
@@ -44,15 +45,29 @@ func countPartWidth(terminal_width, service int) (n int) {
 
 func PrintDividedLine(service string) {
 
-	terminal_width, _ := terminal.Width()
-	n := countPartWidth(int(terminal_width), len(service))
+	if runtime.GOOS == "windows" {
+		n := 20
 
-	fmt.Println()
-	if service == "" {
-		fmt.Println(White(strings.Repeat("-", int(terminal_width))))
+		fmt.Println()
+		if service == "" {
+			fmt.Println(White(strings.Repeat("-", 20)))
+		} else {
+			fmt.Println(White(strings.Repeat("-", n)), Magenta(strings.ToUpper(service)), White(strings.Repeat("-", n)))
+		}
+
 	} else {
-		fmt.Println(White(strings.Repeat("-", n)), Magenta(strings.ToUpper(service)), White(strings.Repeat("-", n)))
+
+		terminal_width, _ := terminal.Width()
+		n := countPartWidth(int(terminal_width), len(service))
+
+		fmt.Println()
+		if service == "" {
+			fmt.Println(White(strings.Repeat("-", int(terminal_width))))
+		} else {
+			fmt.Println(White(strings.Repeat("-", n)), Magenta(strings.ToUpper(service)), White(strings.Repeat("-", n)))
+		}
 	}
+
 }
 
 func ProcessServiceArgument(str string) []string {


### PR DESCRIPTION
I had trouble running aws_enumerator on windows because the terminal package doesn't appear to work well with windows powershell or windows terminal. So I added a runtime check to ensure that if we're running in windows it uses a static number of dashes for each service when dumping privileges.

I additionally, added a bit of code that will print out the successfully identified services with allow permissions after enumeration finishes so we don't have to scroll through a long list and potentially miss some services due to the grouping / strain on eyes.