### PR TITLE
Adding the --clear-empty flag

### DIFF
--- a/helper/helper.go
+++ b/helper/helper.go
@@ -35,15 +35,15 @@ func SetEnumerationPipeline(services, speed *string) {
 	}
 }
 
-func DumpInfo(services_dump *string, print_apicalls *bool, filter *string, errors_dump *bool) {
+func DumpInfo(services_dump *string, print_apicalls *bool, filter *string, errors_dump *bool, clear_empty *bool) {
 	if *services_dump == "all" {
 		for _, service := range utils.ServiceNames() {
-			utils.AnalyseService(service, *print_apicalls, *filter, *errors_dump)
+			utils.AnalyseService(service, *print_apicalls, *filter, *errors_dump, *clear_empty)
 		}
 		fmt.Println()
 	} else {
 		for _, service := range utils.ProcessServiceArgument(*services_dump) {
-			utils.AnalyseService(service, *print_apicalls, *filter, *errors_dump)
+			utils.AnalyseService(service, *print_apicalls, *filter, *errors_dump, *clear_empty)
 		}
 		fmt.Println()
 	}
@@ -94,6 +94,7 @@ Flags:
   -filter       Retrieve only wanted API Call Names by filtering the name. Additional flag. (Filters by first specified chars)
   -print        Print data for a specified service API Calls Get the list of accessible apicalls. Additional flag.
   -errors       Analyse errors returned by AWS API for a specific service. Additional flag.
+  -clear-empty  Hide services with empty results ({}). Suppresses "No entries in provided service" output.
 
 Example:
   #1 
@@ -107,6 +108,7 @@ Example:
   ./aws-enumerator dump -services all -filter Get
   ./aws-enumerator dump -services all -filter Get -print
   ./aws-enumerator dump -services all -filter Get -print -errors
+  ./aws-enumerator dump -services all -filter Get -print -clear-empty
 `
 
 // Command line flags:
@@ -126,3 +128,4 @@ var Services_dump *string = Dump.String("services", "all", "")
 var Errors_dump *bool = Dump.Bool("errors", false, "")
 var Print *bool = Dump.Bool("print", false, "")
 var Filter *string = Dump.String("filter", "", "")
+var Clear_empty *bool = Dump.Bool("clear-empty", false, "")

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ func main() {
 
 	case "dump":
 		helper.Dump.Parse(os.Args[2:])
-		helper.DumpInfo(helper.Services_dump, helper.Print, helper.Filter, helper.Errors_dump)
+		helper.DumpInfo(helper.Services_dump, helper.Print, helper.Filter, helper.Errors_dump, helper.Clear_empty)
 
 	default:
 		fmt.Println(helper.Cloudrider_help)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -122,12 +122,14 @@ func CheckEnvFileExistance() bool {
 	return true
 }
 
-func CheckFileExistance(path string) bool {
+func CheckFileExistance(path string, clear_empty bool) bool {
 	if _, err := os.Stat(path); err != nil {
 		if os.IsNotExist(err) {
-			fmt.Println(Red("Error:"), Yellow("File"), Yellow(path), Yellow("does not exist"))
-			fmt.Println(Green("Fix:"), Yellow("DB does not exist, skip this service"))
-			//fmt.Println(Red("Trace:"), Yellow(err))
+			if !clear_empty {
+				fmt.Println(Red("Error:"), Yellow("File"), Yellow(path), Yellow("does not exist"))
+				fmt.Println(Green("Fix:"), Yellow("DB does not exist, skip this service"))
+				//fmt.Println(Red("Trace:"), Yellow(err))
+			}
 			return false
 		}
 	}
@@ -192,7 +194,7 @@ func GetJsonFromFile(filepath string) (result map[string]interface{}) {
 	return result
 }
 
-func AnalyseService(service string, print bool, filter string, errors_dump bool) {
+func AnalyseService(service string, print bool, filter string, errors_dump bool, clear_empty bool) {
 
 	// Error or result analyse
 	var filepath string
@@ -201,17 +203,22 @@ func AnalyseService(service string, print bool, filter string, errors_dump bool)
 	} else {
 		filepath = ERROR_FILEPATH + service + "_errors.json"
 	}
-
-	// Display
-	PrintDividedLine(strings.ToUpper(service))
-	fmt.Println("")
-
+	
 	// Check the file existance
-	if CheckFileExistance(filepath) {
-
+	if CheckFileExistance(filepath, clear_empty) {
+			
 		// dump service db_file
 		result := GetJsonFromFile(filepath)
 
+		// // Skip display if empty and clear-empty flag is enabled
+		if len(result) == 0 && clear_empty {
+		    return
+		}
+		
+		// Display service
+		PrintDividedLine(strings.ToUpper(service))
+		fmt.Println("")
+		
 		// check whether any info was stored
 		if len(result) == 0 {
 			fmt.Println(Red("Error:"), Yellow("No entries in provided service"))


### PR DESCRIPTION
Hello,

I added a `--clear-empty` flag to limit the output of services that did not return any entries or that were not scanned.

Without the `--clear-empty` flag:
<img width="934" height="776" alt="Capture d’écran 2025-09-22 à 17 30 24" src="https://github.com/user-attachments/assets/694e7498-da60-42c0-a4e6-4b4eb8518f32" />


With the `--clear-empty` flag:
<img width="939" height="749" alt="Capture d’écran 2025-09-22 à 17 32 59" src="https://github.com/user-attachments/assets/26659513-e24b-482e-86a9-457030dc0322" />

Thanks